### PR TITLE
Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 cdk.out
 mt.ts
 .local
+.npmrc

--- a/.version-change-type
+++ b/.version-change-type
@@ -1,1 +1,1 @@
-major
+patch

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 Initial release
+Better AWS credential chain error handling

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tinystacks/aws-template-checks",
-  "version": "0.0.2-local.1",
+  "version": "0.0.2-local.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tinystacks/aws-template-checks",
-      "version": "0.0.2-local.1",
+      "version": "0.0.2-local.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.252.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,24 @@
 {
   "name": "@tinystacks/aws-template-checks",
-  "version": "0.0.1",
+  "version": "0.0.2-local.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tinystacks/aws-template-checks",
-      "version": "0.0.1",
+      "version": "0.0.2-local.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.252.0",
         "@aws-sdk/client-s3": "^3.252.0",
         "@aws-sdk/client-service-quotas": "^3.252.0",
         "@aws-sdk/credential-providers": "^3.252.0",
-        "husky": "^8.0.3"
+        "lodash.isnil": "^4.0.0"
       },
       "devDependencies": {
-        "@tinystacks/precloud": "^1.0.2",
+        "@tinystacks/precloud": "^1.0.3",
         "@types/jest": "^28.1.7",
+        "@types/lodash.isnil": "^4.0.7",
         "@types/node": "^18.11.15",
         "@typescript-eslint/eslint-plugin": "^5.33.1",
         "@typescript-eslint/parser": "^5.33.1",
@@ -27,6 +28,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-tsdoc": "^0.2.17",
         "eslint-plugin-unused-imports": "^2.0.0",
+        "husky": "^8.0.3",
         "jest": "^28.1.3",
         "lodash.isempty": "^4.4.0",
         "ts-jest": "^28.0.8",
@@ -417,6 +419,977 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.256.0.tgz",
+      "integrity": "sha512-YO9xJztpuLCZ7ck2zpT7L194F08CjtXNjX8TkrDeRxfL2Jn96VN6GJY8dcQKy+zRvMr3pqlH/OWyH5pRnC4oeA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.256.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/credential-provider-node": "3.256.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/md5-js": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-signing": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.254.0.tgz",
+      "integrity": "sha512-ZBJFCCU7mIXGLk5GFXrSReyUR/kOBju0kzd7nVAAQQlfkmHZEuFhKFFMXkfJZG0SC0ezCbmR/EzIqJ2mTI+pRA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.256.0.tgz",
+      "integrity": "sha512-e+BNJ95IqUU1nmmX51T3ehy8yqHDN8J4DH6FReK1vrFIMEra/wERGJBcm+pdojyllQ20FQRBvGtOzN/WspH74w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.256.0.tgz",
+      "integrity": "sha512-HR57pMdL5zGpxHnKYx1HjgnbVYlhTDZwyBS7k9JfiEDwPnGH8y169aNgVs+iaX0rIRlv6AyVstjqjZXGxODS4w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.256.0.tgz",
+      "integrity": "sha512-6jqaM7/Lw41kuEz8CqLU+fOLDF8C6W+jG30zBQrAC+iYSTB0w9uGOzVxsan1Nesg1FpoBqnWcF7xWi6Ox+OeDg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/credential-provider-node": "3.256.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-sdk-sts": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-signing": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.254.0.tgz",
+      "integrity": "sha512-+t5mi/SrZdAbSgg/5b/q3zVZsNQSyty2XX+znaRvBdANtIWIBdFLEMQp/L5NA+PSiW6VUXu9eXcsj0kJlAhTgQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.254.0.tgz",
+      "integrity": "sha512-2CDwb7L1XGTY7Y8N3EsE1xqas0zNvrs4aOEv5XZNrKqE+9bvs8CiUwV4SB6VwSD+EPcOSm3QYEURUmj5EyLEZQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.254.0.tgz",
+      "integrity": "sha512-sM3N7FLz+svRGjTgwAybKBmu5tVfCJmd5HPEfKR0jfBWB1uq0u0J+65JiO/wfqn/ix+3ZyFfacSJDFjnSPu/KA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.256.0.tgz",
+      "integrity": "sha512-tZacj/dVnu2GuNSVpYaO6JHrpaWqz9wvOkf/lYxh1Ga993uhF6SWLfENM29gF/EjvV0Nn0beHfyz5Em7dFbw8g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.254.0",
+        "@aws-sdk/credential-provider-imds": "3.254.0",
+        "@aws-sdk/credential-provider-process": "3.254.0",
+        "@aws-sdk/credential-provider-sso": "3.256.0",
+        "@aws-sdk/credential-provider-web-identity": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.256.0.tgz",
+      "integrity": "sha512-A/C8379FjeDYzfG+KQOyMgUnH/Fr7MFoeyhH9pECp5KWzts6H4IIQ1XUN7H/dmeqGfFxU7E7Hya2k1BX4qrKwQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.254.0",
+        "@aws-sdk/credential-provider-imds": "3.254.0",
+        "@aws-sdk/credential-provider-ini": "3.256.0",
+        "@aws-sdk/credential-provider-process": "3.254.0",
+        "@aws-sdk/credential-provider-sso": "3.256.0",
+        "@aws-sdk/credential-provider-web-identity": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.254.0.tgz",
+      "integrity": "sha512-vNm1AHMu5Lg1kOMk4ucWgaNO4zNAD7aeRssdBMnC7WqRT2xB8CUEWi+zJGNjbxzEeTLXQZuMa1VeRT3nPjYrzg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.256.0.tgz",
+      "integrity": "sha512-5WV62oxuM1LM9udmouxkGbnkN7sKqF4drYBBt2DetQzq4NStaOtZgcY0fxcX/HFv0Q2wjSWCBtDQ31Jo1CJRew==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.256.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/token-providers": "3.256.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.254.0.tgz",
+      "integrity": "sha512-R/5qjAoCHEe7xmY5j0vges4xKpFpTgrwzdST822JVNWUobZmiDUqnn+1Xw4Qmomst625NOpgzsV4JuHsA4a8Ig==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.254.0.tgz",
+      "integrity": "sha512-/bbtNHe5JHFdKnCVr3Zx55sqs4c0F+7f1CC5cvTgH3O46wgIRM/6/rvE0YieXmfm3ho/GOhxBUzy59A0haKQGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/querystring-builder": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/hash-node": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.254.0.tgz",
+      "integrity": "sha512-7FoB6BVbO+Z/NEOHeOAoUTyj8q+Pcdn4QpKvA4epRDrzMNcXy7MUNzzt148nkDssES09rgsN+KM8Zo2qgRYngg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.254.0.tgz",
+      "integrity": "sha512-ueV0tXyGndCTZXnEv+AMeTfu+IqV2QzmGMXcakiwxDjg48H9X/bLnj+C96Sexond8jD8K0ub9HWhkBrvvAXlPA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/md5-js": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.254.0.tgz",
+      "integrity": "sha512-J7PTkuX+E37ed4npAV41B6HDEyqM6f8xmorOPPP9Zu3uoR1FDeymK+U0jqOa8HCWxdOle8h1i3ZfghY1D8bozQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.254.0.tgz",
+      "integrity": "sha512-IT7nDZA6WsaZSNp9M79xfkk/us4kGV4SIZ2R9gHT9MFqdmpmbr3EGhFLKXUHcAZfCcOdw+JNV/wHJiiN1JD/hg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.254.0.tgz",
+      "integrity": "sha512-9fkDtSJdhEr91tWp4zLyKhHDGVyvUA0gDK+6wGYyorKCae2qX2TL+Fl6vsqY4PxrdTpXRBJDlJnEly9i48YKxg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.254.0.tgz",
+      "integrity": "sha512-JG+OoyCMivnqTYiPZxRF+sgYEyQG68+PMl2843owvSxQQ25nH2Ih6DzLqH10c/uAN0PsiA8s/FfJBzhw9Xf0KA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.254.0.tgz",
+      "integrity": "sha512-h3jEw58VUJkfqrwWMmp3Qc8293RFo4LMqxNAVsVwYEG6xb/RQ+JamsOx+t6aDsoOdKqhYngWwDGtgUZQ5wQQvg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.254.0.tgz",
+      "integrity": "sha512-/4tTvAXmIIMCs3giPIXN9aVJUGMoBMWw+9WS22u7nYNzwTe/k30DhS91uvwj7TLOOpFN0IBNXPCJ+T1OZn+ZXQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.254.0.tgz",
+      "integrity": "sha512-nHgris8NmtLzsH5iUA8geW6RAT1VRymjlieKFmM3CAYt2h2X8AtAiL/Wod+Pj3+jjRGk9YeGzOOGbzODHiRxnA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/service-error-classification": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.254.0.tgz",
+      "integrity": "sha512-Y074nmTp07thuOI6GePv8IKdL/OvkO1tn2l7QvnwQa3Sy/HyNai1V3MVtq4hRi1dgDjheKPVHPE+TnOmF3w5uA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.254.0.tgz",
+      "integrity": "sha512-YuItb2nlKADTBItcn68eA8amX4quuR1+0GyFRkwssKS/iTjbIk+3gJ2s1zxkUhlyozH3U38Jvvqd+W9+gNpYIg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.254.0.tgz",
+      "integrity": "sha512-HMVGf+yANjlKCUMFZJU2PNzbI9hbCgL+IX/Y4DGuQW9cp7EgZOxQre1LBKpcCqqPVQ4toIdfNH/K8uM2fpO6dg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.254.0.tgz",
+      "integrity": "sha512-yPWRnjeLC0lPAEQbiqbC3+hnqXZ+uCSoSevGndU5KWMMiXLxKZn7Y0B3kG8NAnNNuPid+wYFWWU9rKiBRvWR/w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.254.0.tgz",
+      "integrity": "sha512-hp5UYRg3ysZXMFMv34nYexyom6Z3pdx+OmisJz4w3AMigT8y57Ps30Vg+1QYaGlQkI4vfvcmdZX2Q+kp+mb9gQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.254.0.tgz",
+      "integrity": "sha512-3Bp3Gp2NOY9gab738xf07TysO5iB0Ib9qRNGDlxX8SX8fZDRnxrF2cn+Tjte42wrO54orwhSyuTaIlAqKeii8Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.254.0.tgz",
+      "integrity": "sha512-DX2WJ3pub+3FF9GpoF5doERCn06MxS/UmmbKnIIokWQHjPZVomNh/1P3Cf9Jn9jeIPgh4UOg0uPD8cUm/cwHQw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/querystring-builder": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/property-provider": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.254.0.tgz",
+      "integrity": "sha512-BLZF/LDFjAgv2ZY0vhThU58k++Aw+SK7qNU7XT0D84q5iWlYRKptQEvSSvIkBSI/rZoppOFhK7W80I8kNNbh+Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.254.0.tgz",
+      "integrity": "sha512-4o/I/qhMUTp70njwWe3ttyRJSAKegnr8l3oVWAf1/q1ZHpcxbRRZEDvrkx4KSunFeXTTGHcff1oyLSRG/cKMsQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.254.0.tgz",
+      "integrity": "sha512-Er+pOGTrPxelrzggibduO+eB1ClaU2BhjA8gd0nORS3kqktQggG3tKmRSIilegi9WOa3awCk6CnnuAf0pBrbUA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.254.0.tgz",
+      "integrity": "sha512-WwRD99dwGo2aIrRjLHUAXaWCZ+3fj88IhIwciWTqrHBS3TQWXllOOQmYo7f+aMBB4Q1K6KdKITNi8L7aUuDv2g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.254.0.tgz",
+      "integrity": "sha512-8GHqMJBBF9yoMBG/Nf9PusUSMFjG8ygps/cSJPlgcG2vbFn8BCdBZVc4ptXqICZUnBB/6lrxy8nCmNUaru48jg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.254.0.tgz",
+      "integrity": "sha512-UH4YTXuG+q004vA+jNrVhrD5XQCIAgpL/eriObJnQpKUVef1mkkEDHZs8+8+ZPsk4p/iBrIJ3lXNf7iDA/BFzw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.254.0.tgz",
+      "integrity": "sha512-9FoEnipA9hAgEp6oqIT3+hobF+JgIXIn5QV8kAB7QGxEDqs/pdpEbGc9qbxi0ghdjvqzOSDir9gNI3w0cL8Aug==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.254.0.tgz",
+      "integrity": "sha512-SI0jz9JfWi1IaakDX/26xliKTIMJpzwwDoyQPEfZ/L0KKdpr2gNhljA3sR2pZ2EM1oqOaXpMHAunSzv7EBpBWg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.256.0.tgz",
+      "integrity": "sha512-R8FnhJShIJsvmDzTG2y8WrJYijY7cmK2G4VqqhOx34jCuDFM1/Ml8BzN/o2RvHzJH/7qCqfUMTsJEpt+KOuMPA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.256.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.254.0.tgz",
+      "integrity": "sha512-xDEDk6ZAGFO0URPgB6R2mvQANYlojHLjLC9zzOzl07F+uqYS30yZDIg4UFcqPt/x48v7mxlKZpbaZgYI2ZLgGA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/url-parser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.254.0.tgz",
+      "integrity": "sha512-Za0JGUa9p5GQ8t2tVtKaRSjLUxrmEdnBlUiZ2zKm86wFxgQnjbMwzD3mvyJ5OaVsXScU5vzc3CXHIXSvS7h7Ng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.254.0.tgz",
+      "integrity": "sha512-vj/s+BuqNKTHN9bsZ/HY7vpBWbo3F+4c3/ZoKSZa5Jc7jAuGCbx3zWwHdJFDgvbqLvsTBw80Q9d/CDy9pKj/tQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.254.0.tgz",
+      "integrity": "sha512-gvD2+Uf60c2BgUYv2d6R4dSpO/CbvybqblgF8lKZCsHkDWzfEdPv9nlJgUWM1cuMKQ0hBZ3cL3ilOwVKRVPyiQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/credential-provider-imds": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.254.0.tgz",
+      "integrity": "sha512-BzBIOnhVrs4RFTpGZErZfAV1VhqWglxn047VYijmCQe8Aejq4mJAaepSwHYar++XC0+pduD5YO8IidW8z/1vQQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.254.0.tgz",
+      "integrity": "sha512-gn7vInNTRBo2QatOB+uU99JwV53wf/zlTUnUK0qOuebtSDLMdiO+msiMi2ctz9vMIrtc2XMXNQro1aE0aUPy4w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-retry": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.254.0.tgz",
+      "integrity": "sha512-IVA4wAOJpVssEIbJmeq1fdDYvrkOqYFK9Pz4tERmMz33003fyY92dU468Lulw8MnsSALYiwWUoWSFg9L5RCTug==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.254.0.tgz",
+      "integrity": "sha512-2HvwH8l7ln4qTDsU3rgH9NvSSo5qhX+2Lenb6XvNnIMkL4r/tPhNIaGKtoQRfpzLH378Mm9XEQnJM5UXFRWuTA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.254.0.tgz",
+      "integrity": "sha512-6nc9bmRP+2JqbBJ5oRZZRU8l35X3VcWF5j8XvmamWjIABsanc6Gv6NV4qAa3imPjIyWNiShZn/YkTBYs1exsdg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -1029,6 +2002,35 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.254.0.tgz",
+      "integrity": "sha512-XlzgCGa3gw6bo1upQI0zssuknt8XXdArz4Zs6UE0D0DJlwHuYLa/iLsUAcACl1iRrWAGajq8nEkn9jO640CQOg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.254.0.tgz",
+      "integrity": "sha512-xDEDk6ZAGFO0URPgB6R2mvQANYlojHLjLC9zzOzl07F+uqYS30yZDIg4UFcqPt/x48v7mxlKZpbaZgYI2ZLgGA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
@@ -1527,6 +2529,20 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
@@ -2092,6 +3108,18 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@cdktf/hcl2json": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@cdktf/hcl2json/-/hcl2json-0.15.1.tgz",
+      "integrity": "sha512-iH+V9ay2R+q5u4sl79ztiB1eTAvjlVBgh/4YkPEK5KqvFYdKY677pWEfWqoX92JuH2dW77bfcXnJJwQYAZCxuA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node-fetch": "^2.6.2",
+        "fs-extra": "^8.1.0",
+        "node-fetch": "^2.6.7"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.1",
@@ -3076,18 +4104,67 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@tinystacks/aws-cdk-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@tinystacks/aws-cdk-parser/-/aws-cdk-parser-0.0.2.tgz",
+      "integrity": "sha512-NSdHt/WS6B5RepqNxXmLMHqML0kxqZBkUyupIU3OobBcZmMrF8hLhhGbZ8h336MVVTNljdju8hDJVHZMfVuOrg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "husky": "^8.0.3"
+      }
+    },
+    "node_modules/@tinystacks/aws-resource-checks": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@tinystacks/aws-resource-checks/-/aws-resource-checks-0.0.1.tgz",
+      "integrity": "sha512-sluSNFDULt6p7WrByUORTxjecShOEe/oh8L5waQ/PgPNLrTrg4YFN740IJft16lLztiASpI6WlD5LlAe9EQG7w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.252.0",
+        "@aws-sdk/client-sqs": "^3.252.0",
+        "@aws-sdk/credential-providers": "^3.252.0",
+        "husky": "^8.0.3",
+        "lodash.get": "^4.4.2",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1"
+      }
+    },
+    "node_modules/@tinystacks/aws-template-checks": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@tinystacks/aws-template-checks/-/aws-template-checks-0.0.1.tgz",
+      "integrity": "sha512-HqKltfJs/ykgIlgtziacmVUPohpNPLaWHUSs8QjInP0oAiGjl/CmPSk4uJTERWedzDpYvDAwYEKpRJmogyIkpQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-ec2": "^3.252.0",
+        "@aws-sdk/client-s3": "^3.252.0",
+        "@aws-sdk/client-service-quotas": "^3.252.0",
+        "@aws-sdk/credential-providers": "^3.252.0",
+        "husky": "^8.0.3"
+      }
+    },
     "node_modules/@tinystacks/precloud": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tinystacks/precloud/-/precloud-1.0.2.tgz",
-      "integrity": "sha512-ldxewz8cM+2PhcDHh3HSTJHgMgSWcjGDKZx1kmmVZfaAPvfZeBVr7NnLyMiGjWw/PNUyrp39rT1vgEoCfGY75g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tinystacks/precloud/-/precloud-1.0.3.tgz",
+      "integrity": "sha512-gOtwLhvSupvz37056d3TshgfA6KJ1kXKQVxKlIRC2rpVghZyfZpNWVbR/Z0YnU9hy4Cic+yJV+aAOLbUEZngwQ==",
       "dev": true,
       "dependencies": {
         "colors": "^1.4.0",
         "commander": "^10.0.0",
+        "husky": "^8.0.3",
         "lodash.isnil": "^4.0.0"
       },
       "bin": {
         "precloud": "dist/index.js"
+      },
+      "peerDependencies": {
+        "@tinystacks/aws-cdk-parser": "0.x",
+        "@tinystacks/aws-resource-checks": "0.x",
+        "@tinystacks/aws-template-checks": "0.x",
+        "@tinystacks/terraform-module-parser": "0.x",
+        "@tinystacks/terraform-resource-parser": "0.x"
       }
     },
     "node_modules/@tinystacks/precloud/node_modules/commander": {
@@ -3097,6 +4174,35 @@
       "dev": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@tinystacks/terraform-module-parser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@tinystacks/terraform-module-parser/-/terraform-module-parser-0.0.1.tgz",
+      "integrity": "sha512-jL4aTzhH7Ode6jba5oRKTL5e5GSGXelP0CPWwxuPUdi0hKhq6LWTACR33e5rJbYW7b2QeVANeLYeUSHEVswK1Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@cdktf/hcl2json": "^0.15.0",
+        "cached": "^6.1.0",
+        "lodash.get": "^4.4.2",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isplainobject": "^4.0.6"
+      }
+    },
+    "node_modules/@tinystacks/terraform-resource-parser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@tinystacks/terraform-resource-parser/-/terraform-resource-parser-0.0.1.tgz",
+      "integrity": "sha512-N3zCuQH92MOEfVlSHR9F4lP2Yz5NCKV7FVZmt7q+Vv8+4f0YMFlzigdiC6c2UFEYgFRF9sR67BF3Amcl/fJplQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@cdktf/hcl2json": "^0.15.0",
+        "cached": "^6.1.0",
+        "husky": "^8.0.3",
+        "lodash.get": "^4.4.2",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "node_modules/@types/babel__core": {
@@ -3207,6 +4313,21 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.isnil": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isnil/-/lodash.isnil-4.0.7.tgz",
+      "integrity": "sha512-jMMa3G3nJCk+agAWJmrmpr4dYurU6F5SdhQuouhFxKE3mdmqI0lLAI6G72NBW+sxfLVnxZymjqj5nRwonqASZw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -3218,6 +4339,17 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
       "dev": true
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -3691,6 +4823,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -3879,6 +5018,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -3960,6 +5106,20 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/cached": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cached/-/cached-6.1.0.tgz",
+      "integrity": "sha512-1zFJAmD0QibGJB2+mq9SEz4tYuu+u4oKd3oG/626hzAigvmer4RX8FpytfpE4+hEMgpHdRV3jtXKq/dPoE4KzQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "memcached-elasticache": "^1.1.1",
+        "redis": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -4145,11 +5305,31 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/connection-parse": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+      "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
@@ -4248,6 +5428,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depcheck": {
@@ -5232,6 +6432,36 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5556,6 +6786,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashring": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+      "integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "connection-parse": "0.0.x",
+        "simple-lru-cache": "0.0.x"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5575,6 +6816,7 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
       "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
       "bin": {
         "husky": "lib/bin.js"
       },
@@ -6094,6 +7336,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackpot": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
+      "integrity": "sha512-rbWXX+A9ooq03/dfavLg9OXQ8YB57Wa7PY5c4LfU3CgFpwEhhl3WyXTQVurkaT7zBM5I9SSOaiLyJ4I0DQmC0g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "retry": "0.6.0"
       }
     },
     "node_modules/jest": {
@@ -7737,6 +8989,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -7795,6 +9057,13 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
@@ -7804,8 +9073,21 @@
     "node_modules/lodash.isnil": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
-      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
-      "dev": true
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -7888,6 +9170,29 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/memcached": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
+      "integrity": "sha512-lHwUmqkT9WdUUgRsAvquO4xsKXYaBd644Orz31tuth+w/BIfFNuJMWwsG7sa7H3XXytaNfPTZ5R/yOG3d9zJMA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "hashring": "3.2.x",
+        "jackpot": ">=0.0.6"
+      }
+    },
+    "node_modules/memcached-elasticache": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/memcached-elasticache/-/memcached-elasticache-1.1.1.tgz",
+      "integrity": "sha512-jPPgHzuGDBQqgDGTe16sIYV09G3Ch/MjI51ZDA4xcIhmdWrRsOYvSZn9OboeRV8pvEr74x1D3ty0GZVwCP+nKA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "lodash": "^4.17.4",
+        "memcached": "^2.2.2"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7914,6 +9219,29 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -7994,6 +9322,27 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
+      "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -8480,6 +9829,56 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-redis"
+      }
+    },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -8578,6 +9977,16 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+      "integrity": "sha512-RgncoxLF1GqwAzTZs/K2YpZkWrdIYbXsmesdomi+iPilSzjUyr/wzNIuteoTVaWokzdwZIJ9NHRNQa/RUiOB2g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/reusify": {
@@ -8751,6 +10160,13 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-lru-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+      "integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -9087,6 +10503,13 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/ts-jest": {
       "version": "28.0.8",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.8.tgz",
@@ -9264,6 +10687,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -9328,6 +10761,24 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinystacks/aws-template-checks",
-  "version": "0.0.2-local.1",
+  "version": "0.0.2-local.3",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinystacks/aws-template-checks",
-  "version": "0.0.1",
+  "version": "0.0.2-local.1",
   "description": "",
   "main": "dist/index.js",
   "files": [
@@ -42,8 +42,9 @@
   },
   "homepage": "https://github.com/tinystacks/aws-template-checks#readme",
   "devDependencies": {
-    "@tinystacks/precloud": "^1.0.2",
+    "@tinystacks/precloud": "^1.0.3",
     "@types/jest": "^28.1.7",
+    "@types/lodash.isnil": "^4.0.7",
     "@types/node": "^18.11.15",
     "@typescript-eslint/eslint-plugin": "^5.33.1",
     "@typescript-eslint/parser": "^5.33.1",
@@ -53,6 +54,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-tsdoc": "^0.2.17",
     "eslint-plugin-unused-imports": "^2.0.0",
+    "husky": "^8.0.3",
     "jest": "^28.1.3",
     "lodash.isempty": "^4.4.0",
     "ts-jest": "^28.0.8",
@@ -63,6 +65,6 @@
     "@aws-sdk/client-s3": "^3.252.0",
     "@aws-sdk/client-service-quotas": "^3.252.0",
     "@aws-sdk/credential-providers": "^3.252.0",
-    "husky": "^8.0.3"
+    "lodash.isnil": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test-cov": "jest --coverage",
     "test-file": "jest ./test/vpc-quota-checks.test.ts",
     "test-file-cov": "jest ./test/cli/commands/smoke-test/smoke-tests/aws/resource-tests/vpc-smoke-tests.test.ts --coverage",
-    "view-test-cov": "jest --coverage && open coverage/lcov-report/index.html",
+    "view-test-cov": "jest --coverage || true && open coverage/lcov-report/index.html",
     "prepare": "husky install"
   },
   "repository": {

--- a/src/eip-quota-checks.ts
+++ b/src/eip-quota-checks.ts
@@ -25,7 +25,7 @@ async function checkEipQuota (resources: ResourceDiffRecord[]) {
   const config = { credentials: await getCredentials() };
 
   const quotaClient = new ServiceQuotas(config);
-  const quotaResponse = await quotaClient.getAWSDefaultServiceQuota({
+  const quotaResponse = await quotaClient.getServiceQuota({
     ServiceCode: 'ec2',
     QuotaCode: 'L-0263D0A3'
   });

--- a/src/s3-quota-checks.ts
+++ b/src/s3-quota-checks.ts
@@ -25,7 +25,7 @@ async function checkS3Quota (resources: ResourceDiffRecord[]) {
   const config = { credentials: await getCredentials() };
 
   const quotaClient = new ServiceQuotas(config);
-  const quotaResponse = await quotaClient.getAWSDefaultServiceQuota({
+  const quotaResponse = await quotaClient.getServiceQuota({
     ServiceCode: 's3',
     QuotaCode: 'L-DC2B2D3D'
   });

--- a/src/s3-quota-checks.ts
+++ b/src/s3-quota-checks.ts
@@ -25,7 +25,12 @@ async function checkS3Quota (resources: ResourceDiffRecord[]) {
   const config = { credentials: await getCredentials() };
 
   const quotaClient = new ServiceQuotas(config);
-  const quotaResponse = await quotaClient.getServiceQuota({
+  /**
+   * Only the default quota can be requested, requesting the applied quota results in a NoSuchResourceException
+   * Source: https://repost.aws/questions/QUPb4JLtvsTJ6gaYeNn1KcqQ/aws-cli-service-quotas-results-in-error
+   * Check for yourself: aws service-quotas get-service-quota --service-code s3 --quota-code L-DC2B2D3D;
+   * */
+  const quotaResponse = await quotaClient.getAWSDefaultServiceQuota({
     ServiceCode: 's3',
     QuotaCode: 'L-DC2B2D3D'
   });

--- a/src/utils/aws/index.ts
+++ b/src/utils/aws/index.ts
@@ -2,13 +2,17 @@ import {
   fromNodeProviderChain,
   fromEnv
 } from '@aws-sdk/credential-providers';
+import { CliError } from '@tinystacks/precloud';
+import isNil from 'lodash.isnil';
 
 async function getCredentials () {
   const envProvider = fromEnv();
-  const envCreds = await envProvider();
+  const envCreds = await envProvider().catch(() => undefined);
   const nodeChainProvider = fromNodeProviderChain();
-  const nodeChainCreds = await nodeChainProvider();
-  return envCreds || nodeChainCreds;
+  const nodeChainCreds = await nodeChainProvider().catch(() => undefined);
+  const creds = envCreds || nodeChainCreds;
+  if (isNil(creds)) throw new CliError('Failed to detect AWS credentials!', 'AWS credentials were not found in the environment or anywhere else on the node chain provider.', 'Make sure you are authenticated to the AWS account you plan to deploy to.');
+  return creds;
 }
 
 export {

--- a/src/vpc-quota-checks.ts
+++ b/src/vpc-quota-checks.ts
@@ -25,7 +25,7 @@ async function checkVpcQuota (resources: ResourceDiffRecord[]) {
   const config = { credentials: await getCredentials() };
 
   const quotaClient = new ServiceQuotas(config);
-  const quotaResponse = await quotaClient.getAWSDefaultServiceQuota({
+  const quotaResponse = await quotaClient.getServiceQuota({
     ServiceCode: 'vpc',
     QuotaCode: 'L-F678F1CE'
   });

--- a/test/eip-quota-checks.test.ts
+++ b/test/eip-quota-checks.test.ts
@@ -2,7 +2,7 @@ const mockLoggerInfo = jest.fn();
 const mockGetCredentials = jest.fn();
 const mockDescribeAddresses = jest.fn();
 const mockEc2 = jest.fn();
-const mockGetAwsDefaultServiceQuota = jest.fn();
+const mockGetServiceQuota = jest.fn();
 const mockServiceQuotas = jest.fn();
 
 jest.mock('@tinystacks/precloud', () => {
@@ -49,7 +49,7 @@ describe('eip smoke tests', () => {
       describeAddresses: mockDescribeAddresses
     });
     mockServiceQuotas.mockReturnValue({
-      getAWSDefaultServiceQuota: mockGetAwsDefaultServiceQuota
+      getServiceQuota: mockGetServiceQuota
     });
   });
 
@@ -71,7 +71,7 @@ describe('eip smoke tests', () => {
       expect(mockLoggerInfo).not.toBeCalled();
       expect(mockGetCredentials).not.toBeCalled();
       expect(mockServiceQuotas).not.toBeCalled();
-      expect(mockGetAwsDefaultServiceQuota).not.toBeCalled();
+      expect(mockGetServiceQuota).not.toBeCalled();
       expect(mockEc2).not.toBeCalled();
       expect(mockDescribeAddresses).not.toBeCalled();
     });
@@ -83,7 +83,7 @@ describe('eip smoke tests', () => {
         properties: {}
       } as unknown as ResourceDiffRecord;
 
-      mockGetAwsDefaultServiceQuota.mockResolvedValueOnce({
+      mockGetServiceQuota.mockResolvedValueOnce({
         Quota: {
           Value: 5
         }
@@ -98,7 +98,7 @@ describe('eip smoke tests', () => {
       expect(mockLoggerInfo).toBeCalled();
       expect(mockLoggerInfo).toBeCalledWith('Checking Elastic IP service quota...');
       expect(mockGetCredentials).toBeCalled();
-      expect(mockGetAwsDefaultServiceQuota).toBeCalled();
+      expect(mockGetServiceQuota).toBeCalled();
       expect(mockDescribeAddresses).toBeCalled();
     });
     it('throws a QuotaError if new eip would exceed quota limit', async () => {
@@ -109,7 +109,7 @@ describe('eip smoke tests', () => {
         properties: {}
       } as unknown as ResourceDiffRecord;
       
-      mockGetAwsDefaultServiceQuota.mockResolvedValueOnce({
+      mockGetServiceQuota.mockResolvedValueOnce({
         Quota: {
           Value: 5
         }
@@ -127,7 +127,7 @@ describe('eip smoke tests', () => {
         expect(mockLoggerInfo).toBeCalled();
         expect(mockLoggerInfo).toBeCalledWith('Checking Elastic IP service quota...');
         expect(mockGetCredentials).toBeCalled();
-        expect(mockGetAwsDefaultServiceQuota).toBeCalled();
+        expect(mockGetServiceQuota).toBeCalled();
         expect(mockDescribeAddresses).toBeCalled();
 
         expect(thrownError).not.toBeUndefined();

--- a/test/s3-quota-checks.test.ts
+++ b/test/s3-quota-checks.test.ts
@@ -3,7 +3,7 @@ const mockGetCredentials = jest.fn();
 const mockListBuckets = jest.fn();
 const mockHeadBucket = jest.fn();
 const mockS3 = jest.fn();
-const mockGetServiceQuota = jest.fn();
+const mockGetAWSDefaultServiceQuota = jest.fn(); mockGetAWSDefaultServiceQuota
 const mockServiceQuotas = jest.fn();
 
 jest.mock('@tinystacks/precloud', () => {
@@ -51,7 +51,7 @@ describe('s3 smoke tests', () => {
       headBucket: mockHeadBucket
     });
     mockServiceQuotas.mockReturnValue({
-      getServiceQuota: mockGetServiceQuota
+      getAWSDefaultServiceQuota: mockGetAWSDefaultServiceQuota
     });
   });
 
@@ -85,7 +85,7 @@ describe('s3 smoke tests', () => {
         }
       } as unknown as ResourceDiffRecord;
 
-      mockGetServiceQuota.mockResolvedValueOnce({
+      mockGetAWSDefaultServiceQuota.mockResolvedValueOnce({
         Quota: {
           Value: 100
         }
@@ -99,7 +99,7 @@ describe('s3 smoke tests', () => {
       expect(mockLoggerInfo).toBeCalled();
       expect(mockLoggerInfo).toBeCalledWith('Checking S3 bucket service quota...');
       expect(mockGetCredentials).toBeCalled();
-      expect(mockGetServiceQuota).toBeCalled();
+      expect(mockGetAWSDefaultServiceQuota).toBeCalled();
       expect(mockListBuckets).toBeCalled();
     });
     it('throws a QuotaError if new bucket would exceed quota limit', async () => {
@@ -112,7 +112,7 @@ describe('s3 smoke tests', () => {
         }
       } as unknown as ResourceDiffRecord;
       
-      mockGetServiceQuota.mockResolvedValueOnce({
+      mockGetAWSDefaultServiceQuota.mockResolvedValueOnce({
         Quota: {
           Value: 100
         }
@@ -130,7 +130,7 @@ describe('s3 smoke tests', () => {
         expect(mockLoggerInfo).toBeCalledTimes(1);
         expect(mockLoggerInfo).toBeCalledWith('Checking S3 bucket service quota...');
         expect(mockGetCredentials).toBeCalled();
-        expect(mockGetServiceQuota).toBeCalled();
+        expect(mockGetAWSDefaultServiceQuota).toBeCalled();
         expect(mockListBuckets).toBeCalled();
 
         expect(thrownError).not.toBeUndefined();

--- a/test/s3-quota-checks.test.ts
+++ b/test/s3-quota-checks.test.ts
@@ -3,7 +3,7 @@ const mockGetCredentials = jest.fn();
 const mockListBuckets = jest.fn();
 const mockHeadBucket = jest.fn();
 const mockS3 = jest.fn();
-const mockGetAwsDefaultServiceQuota = jest.fn();
+const mockGetServiceQuota = jest.fn();
 const mockServiceQuotas = jest.fn();
 
 jest.mock('@tinystacks/precloud', () => {
@@ -51,7 +51,7 @@ describe('s3 smoke tests', () => {
       headBucket: mockHeadBucket
     });
     mockServiceQuotas.mockReturnValue({
-      getAWSDefaultServiceQuota: mockGetAwsDefaultServiceQuota
+      getServiceQuota: mockGetServiceQuota
     });
   });
 
@@ -85,7 +85,7 @@ describe('s3 smoke tests', () => {
         }
       } as unknown as ResourceDiffRecord;
 
-      mockGetAwsDefaultServiceQuota.mockResolvedValueOnce({
+      mockGetServiceQuota.mockResolvedValueOnce({
         Quota: {
           Value: 100
         }
@@ -99,7 +99,7 @@ describe('s3 smoke tests', () => {
       expect(mockLoggerInfo).toBeCalled();
       expect(mockLoggerInfo).toBeCalledWith('Checking S3 bucket service quota...');
       expect(mockGetCredentials).toBeCalled();
-      expect(mockGetAwsDefaultServiceQuota).toBeCalled();
+      expect(mockGetServiceQuota).toBeCalled();
       expect(mockListBuckets).toBeCalled();
     });
     it('throws a QuotaError if new bucket would exceed quota limit', async () => {
@@ -112,7 +112,7 @@ describe('s3 smoke tests', () => {
         }
       } as unknown as ResourceDiffRecord;
       
-      mockGetAwsDefaultServiceQuota.mockResolvedValueOnce({
+      mockGetServiceQuota.mockResolvedValueOnce({
         Quota: {
           Value: 100
         }
@@ -130,7 +130,7 @@ describe('s3 smoke tests', () => {
         expect(mockLoggerInfo).toBeCalledTimes(1);
         expect(mockLoggerInfo).toBeCalledWith('Checking S3 bucket service quota...');
         expect(mockGetCredentials).toBeCalled();
-        expect(mockGetAwsDefaultServiceQuota).toBeCalled();
+        expect(mockGetServiceQuota).toBeCalled();
         expect(mockListBuckets).toBeCalled();
 
         expect(thrownError).not.toBeUndefined();

--- a/test/utils/aws/index.test.ts
+++ b/test/utils/aws/index.test.ts
@@ -28,12 +28,29 @@ describe('aws utils', () => {
       expect(result).toEqual('env-creds');
     });
     it('return credentials from node provider chain if environment credentials are nil', async () => {
-      mockFromEnv.mockReturnValueOnce((): any => undefined);
-      mockFromNodeProviderChain.mockReturnValueOnce(() => 'chain-creds');
+      mockFromEnv.mockReturnValueOnce(async (): Promise<any> => undefined);
+      mockFromNodeProviderChain.mockReturnValueOnce(async () => 'chain-creds');
 
       const result = await getCredentials();
 
       expect(result).toEqual('chain-creds');
+    });
+    it('throws if both node provider chain and environment credentials are nil', async () => {
+      mockFromEnv.mockReturnValueOnce(async () => { throw new Error('Error!') });
+      mockFromNodeProviderChain.mockReturnValueOnce(async (): Promise<any> => undefined);
+
+      let thrownError;
+      try {
+        await getCredentials();
+      } catch (error) {
+        thrownError = error;
+      } finally {
+        expect(thrownError).toBeDefined();
+        expect(thrownError).toHaveProperty('name', 'CliError');
+        expect(thrownError).toHaveProperty('message', 'Failed to detect AWS credentials!');
+        expect(thrownError).toHaveProperty('reason', 'AWS credentials were not found in the environment or anywhere else on the node chain provider.');
+        expect(thrownError).toHaveProperty('hints', ['Make sure you are authenticated to the AWS account you plan to deploy to.']);
+      }
     });
   });
 });

--- a/test/utils/aws/index.test.ts
+++ b/test/utils/aws/index.test.ts
@@ -37,7 +37,7 @@ describe('aws utils', () => {
     });
     it('throws if both node provider chain and environment credentials are nil', async () => {
       mockFromEnv.mockReturnValueOnce(async () => { throw new Error('Error!') });
-      mockFromNodeProviderChain.mockReturnValueOnce(async (): Promise<any> => undefined);
+      mockFromNodeProviderChain.mockReturnValueOnce(async () => { throw new Error('Error!') });
 
       let thrownError;
       try {

--- a/test/utils/aws/index.test.ts
+++ b/test/utils/aws/index.test.ts
@@ -36,8 +36,8 @@ describe('aws utils', () => {
       expect(result).toEqual('chain-creds');
     });
     it('throws if both node provider chain and environment credentials are nil', async () => {
-      mockFromEnv.mockReturnValueOnce(async () => { throw new Error('Error!') });
-      mockFromNodeProviderChain.mockReturnValueOnce(async () => { throw new Error('Error!') });
+      mockFromEnv.mockReturnValueOnce(async () => { throw new Error('Error!'); });
+      mockFromNodeProviderChain.mockReturnValueOnce(async () => { throw new Error('Error!'); });
 
       let thrownError;
       try {

--- a/test/vpc-quota-checks.test.ts
+++ b/test/vpc-quota-checks.test.ts
@@ -2,7 +2,7 @@ const mockLoggerInfo = jest.fn();
 const mockGetCredentials = jest.fn();
 const mockDescribeVpcs = jest.fn();
 const mockEc2 = jest.fn();
-const mockGetAwsDefaultServiceQuota = jest.fn();
+const mockGetServiceQuota = jest.fn();
 const mockServiceQuotas = jest.fn();
 
 jest.mock('@tinystacks/precloud', () => {
@@ -49,7 +49,7 @@ describe('vpc smoke tests', () => {
       describeVpcs: mockDescribeVpcs
     });
     mockServiceQuotas.mockReturnValue({
-      getAWSDefaultServiceQuota: mockGetAwsDefaultServiceQuota
+      getServiceQuota: mockGetServiceQuota
     });
   });
 
@@ -71,7 +71,7 @@ describe('vpc smoke tests', () => {
       expect(mockLoggerInfo).not.toBeCalled();
       expect(mockGetCredentials).not.toBeCalled();
       expect(mockServiceQuotas).not.toBeCalled();
-      expect(mockGetAwsDefaultServiceQuota).not.toBeCalled();
+      expect(mockGetServiceQuota).not.toBeCalled();
       expect(mockEc2).not.toBeCalled();
       expect(mockDescribeVpcs).not.toBeCalled();
     });
@@ -85,7 +85,7 @@ describe('vpc smoke tests', () => {
         }
       } as unknown as ResourceDiffRecord;
 
-      mockGetAwsDefaultServiceQuota.mockResolvedValueOnce({
+      mockGetServiceQuota.mockResolvedValueOnce({
         Quota: {
           Value: 5
         }
@@ -100,7 +100,7 @@ describe('vpc smoke tests', () => {
       expect(mockLoggerInfo).toBeCalled();
       expect(mockLoggerInfo).toBeCalledWith('Checking VPC service quota...');
       expect(mockGetCredentials).toBeCalled();
-      expect(mockGetAwsDefaultServiceQuota).toBeCalled();
+      expect(mockGetServiceQuota).toBeCalled();
       expect(mockDescribeVpcs).toBeCalled();
     });
     it('throws a QuotaError if new vpc would exceed quota limit', async () => {
@@ -113,7 +113,7 @@ describe('vpc smoke tests', () => {
         }
       } as unknown as ResourceDiffRecord;
       
-      mockGetAwsDefaultServiceQuota.mockResolvedValueOnce({
+      mockGetServiceQuota.mockResolvedValueOnce({
         Quota: {
           Value: 5
         }
@@ -131,7 +131,7 @@ describe('vpc smoke tests', () => {
         expect(mockLoggerInfo).toBeCalled();
         expect(mockLoggerInfo).toBeCalledWith('Checking VPC service quota...');
         expect(mockGetCredentials).toBeCalled();
-        expect(mockGetAwsDefaultServiceQuota).toBeCalled();
+        expect(mockGetServiceQuota).toBeCalled();
         expect(mockDescribeVpcs).toBeCalled();
 
         expect(thrownError).not.toBeUndefined();


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix
 - [ ] Non-bug Patch (i.e. dependency update, cicd update, etc.)

## Link to Notion Task or Github Issue
<!-- Go to the task, press the ellipsis button (three dots), then click Copy Link -->
<!-- Example: -->
<!-- https://www.notion.so/tinystacks/Add-Linter-to-Templates-6b4b1910281842308c11d14961d01237 -->
N/A - testing

## Summary of Bug Fix(es)
### Previous Behaviour
_Description of the bug and it's impact_
1. Env credentials provider would throw if it couldn't find the credentials preventing us from falling back on the node provider chain.
2. Quota checks were using the default quota instead of the user set quota.

### New Behaviour
_Description of the bug fix and it's impact_
Catch errors from provider methods, check that creds exist, throw if they do not.
2. Switch from `getAWSDefaultServiceQuota` to `getServiceQuota` for all but S3.
        - S3 does not support requesting the applied quota.
        - See issue: https://repost.aws/questions/QUPb4JLtvsTJ6gaYeNn1KcqQ/aws-cli-service-quotas-results-in-error